### PR TITLE
Adicionadas entradas para tratamento da variável validacao-uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker exec -it <nome_do_container> create-admin 'Nome do usuário' 'CPF00000000
 
 ### Carga inicial dos dados do SIORG
 
-Para a inicialização do sistema, é necessário fazer uma pré-carga dos dados de unidades administrativas, o que pode ser feito através do link [http://{endereço do ambiente}/gestaoriscos/api/siorg/importar](http://{endereço do ambiente}/gestaoriscos/api/siorg/importar).
+Para a inicialização do sistema, é necessário fazer uma pré-carga dos dados de unidades administrativas, o que pode ser feito através do link [http://endereço-do-ambiente/gestaoriscos/api/siorg/importar](http://endereço-do-ambiente/gestaoriscos/api/siorg/importar).
 
 ## Versões
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Dentro do container existe um script para criação do usuário administrador, n
 docker exec -it <nome_do_container> create-admin 'Nome do usuário' 'CPF00000000000' 'meuemail@gmail.com'
 ```
 
+### Carga inicial dos dados do SIORG
+
+Para a inicialização do sistema, é necessário fazer uma pré-carga dos dados de unidades administrativas, o que pode ser feito através do link [http://{endereço do ambiente}/gestaoriscos/api/siorg/importar](http://{endereço do ambiente}/gestaoriscos/api/siorg/importar).
+
 ## Versões
 
 Todas as versões deste container podem ser localizadas em [Docker Hub Tags](https://hub.docker.com/r/lucasdiedrich/agatha/tags/).

--- a/files/config/application.yaml
+++ b/files/config/application.yaml
@@ -12,4 +12,5 @@ ecidadao:
   # URIS dO AMBIENTE DE TESTES
   access-token-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/token
   user-authorization-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/authorize
+#  teste validacao-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/jwk
 

--- a/files/config/application.yaml
+++ b/files/config/application.yaml
@@ -12,5 +12,5 @@ ecidadao:
   # URIS dO AMBIENTE DE TESTES
   access-token-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/token
   user-authorization-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/authorize
-#  teste validacao-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/jwk
+#  validacao-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/jwk
 

--- a/files/usr/bin/pre-init
+++ b/files/usr/bin/pre-init
@@ -51,6 +51,7 @@ if [[ "$CONF_CHECK" = "1" ]]; then
         else
             sed -i "/access-token-uri:/c\  access-token-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/token" $APPYAML
             sed -i "/user-authorization-uri:/c\  user-authorization-uri: https://testescp-ecidadao.estaleiro.serpro.gov.br/scp/authorize" $APPYAML
+            sed -i '/validacao-uri:/s/^#//g' $APPYAML
         fi
     else
         echo "ERRO !!!"


### PR DESCRIPTION
Durante a troca de mensagens entre a instituição que trabalho e a
equipe do Agatha, nos foi informado que era necessário adicionar a
variável `validacao-uri` nas configurações do projeto.

Para que isso não influenciasse o deploy da versão de produção dos
containeres, foram adicionadas a variável comentada no arquivo
application.yaml e adicionado comando para descomentar a mesma
quando o ambiente a ser implantado for o ambiente de testes.